### PR TITLE
resolves incomplete object notice

### DIFF
--- a/QueueIT.Security/SessionValidateResultRepository.php
+++ b/QueueIT.Security/SessionValidateResultRepository.php
@@ -53,7 +53,7 @@ class SessionValidateResultRepository extends ValidateResultRepositoryBase
 		if (!isset($_SESSION[$key]))
 			return null;
 		
-		$model = $_SESSION[$key];
+		$model = unserialize($_SESSION[$key]);
 		
 		if ($model->expiration != null && $model->expiration < time())
 			return null;
@@ -95,7 +95,7 @@ class SessionValidateResultRepository extends ValidateResultRepositoryBase
 			$model->expiration = $expiration;
 			
 			$key = $this->generateKey($queue->getCustomerId(), $queue->getEventId());
-			$_SESSION[$key] = $model;
+			$_SESSION[$key] = serialize($model);
 		}		
 	}
 	


### PR DESCRIPTION
2015-04-17 11:47:36 Notice: Notice (8): QueueIT\Security\SessionValidateResultRepository::getValidationResult() [queueit\security\sessionvalidateresultrepository.getvalidationresult]: The script tried to execute a method or access a property of an incomplete object. Please ensure that the class definition "QueueIT\Security\SessionStateModel" of the object you are trying to operate on was loaded before unserialize() gets called or provide a __autoload() function to load the class definition in [.../QueueIT.Security/SessionValidateResultRepository.php, line 66]
